### PR TITLE
feat: adds option to pass a getProcessCommandLine function

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ LeagueClientUx process. If you wish to await until a client is found, you can us
 | unsafe | `false` | If you do not wish to authenticate safely using a self-signed certificate you can authorize while ignoring any certificate rejections. To authenticate this way, set unsafe to `true`. The custom certificate option will take precedence over this, meaning this option is meaningless if a custom certificate is provided. |
 | useDeprecatedWmic | `false` | Use deprecated Windows WMIC command line over Get-CimInstance. Does nothing if the system is not running on Windows. |
 | windowsShell | `powershell` | Set the Windows shell to use. Either powershell or cmd. |
+| getProcessCommandLine | `undefined` | Set custom function to get LeagueClientUx process information. |
 
 ```js
 import { authenticate } from 'league-connect'

--- a/src/tests/authentication.test.ts
+++ b/src/tests/authentication.test.ts
@@ -65,4 +65,13 @@ describe('authenticating to the api', () => {
 
     expect(credentials?.certificate).toBeUndefined()
   })
+
+  test('authentication using get-command-line detection mode', async () => {
+    const credentials = await authenticate({
+      getProcessCommandLine: () => `C:/Riot Games/LeagueClientUx.exe" "--remoting-auth-token=CUSTOM_TOKEN" "--app-port=57730" "--app-pid=28900"`
+    })
+
+    expect(credentials).toBeDefined()
+    expect(credentials?.certificate).toBeDefined()
+  })
 })

--- a/src/tests/authentication.test.ts
+++ b/src/tests/authentication.test.ts
@@ -66,7 +66,7 @@ describe('authenticating to the api', () => {
     expect(credentials?.certificate).toBeUndefined()
   })
 
-  test('authentication using get-command-line detection mode', async () => {
+  test('authentication using getProcessCommandLine option', async () => {
     const credentials = await authenticate({
       getProcessCommandLine: () => `C:/Riot Games/LeagueClientUx.exe" "--remoting-auth-token=CUSTOM_TOKEN" "--app-port=57730" "--app-pid=28900"`
     })


### PR DESCRIPTION
In some cases it may be necessary to use a custom function to retrieve League's command line string, since the current methods (`Get-CimInstance` and `wmic`) rely on WMI, which may be unavailable (or broken) on some Windows machines.

This PR implements @junlarsen's suggestion from the discussion in https://github.com/junlarsen/league-connect/discussions/124.